### PR TITLE
added bool servo_flag_update_angle

### DIFF
--- a/At_Vsido_Connect_Library.cpp
+++ b/At_Vsido_Connect_Library.cpp
@@ -228,6 +228,7 @@ bool At_Vsido_Connect_Library::unpackObjectPacket() {
 		if (!isEXCEPTION_VALUE(servo_angle)) {
 			servo_cycle[servo_id]  = cyc;
 			servo_angles[servo_id] = servo_angle;
+			servo_flag_update_angle[servo_id]=true;
 		}
 
 		//返信データ
@@ -274,6 +275,7 @@ bool At_Vsido_Connect_Library::unpackTorquePacket() {
 		if (!isEXCEPTION_VALUE(servo_torque)) {
 			servo_cycle[servo_id]   = cyc;
 			servo_torques[servo_id] = servo_torque;
+			servo_flag_update_angle[servo_id] = true;
 		}
 		//返信データ
 		unsigned char lower, upper;

--- a/At_Vsido_Connect_Library.cpp
+++ b/At_Vsido_Connect_Library.cpp
@@ -33,6 +33,8 @@ At_Vsido_Connect_Library::At_Vsido_Connect_Library() {
 		servo_status_servoon[id] = false;
 		servo_status_error[id]   = false;
 
+		servo_flag_update_angle[id]=false;
+
 		servo_connected[id] = false;
 	}
 }

--- a/At_Vsido_Connect_Library.h
+++ b/At_Vsido_Connect_Library.h
@@ -40,6 +40,9 @@ class At_Vsido_Connect_Library {
   int servo_torques[VSIDO_MAXSERVO];  //受信した全関節のトルク指示値
   int servo_cycle[VSIDO_MAXSERVO];  //受信した全関節の目標到達時間(cyc)
 
+  // vsido関連 bool
+  bool servo_flag_update_angle[VSIDO_MAXSERVO];
+
   // vsido関連 現在値格納用
   int servo_present_angles[VSIDO_MAXSERVO];  //全関節角度現在値
   int servo_present_torques[VSIDO_MAXSERVO];  //全関節トルク現在値


### PR DESCRIPTION
bool servo_flag_update_angleを追加
servo_flag_update_angleをコンストラクタで初期化
オペランド 't'と'o'で更新される。

制御側で適切に参照するとともに、繁栄が終わったらfalseにする